### PR TITLE
adapt to blackhole v1

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Build-Depends: cmake, cdbs, debhelper (>= 7.0.13),
  libcocaine-dev (>= 0.12),
  libcocaine-plugin-node-dev (>= 0.12.3),
  libmsgpack-dev,
- blackhole5-dev
+ blackhole-dev
 Standards-Version: 3.9.3
 Vcs-Git: git://github.com/cocaine/cocaine-framework-native.git
 Vcs-Browser: https://github.com/cocaine/cocaine-framework-native

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -60,6 +60,7 @@ target_link_libraries(${PROJECT}
     ${Boost_LIBRARIES}
     cocaine-core # Temporary link until required.
     msgpack
+    blackhole
 )
 
 # Try and enable C++11.

--- a/src/trace_logger.cpp
+++ b/src/trace_logger.cpp
@@ -1,3 +1,6 @@
+#include <blackhole/attribute.hpp>
+#include <blackhole/extensions/writer.hpp>
+
 #include "cocaine/framework/detail/log.hpp"
 #include "cocaine/framework/trace.hpp"
 
@@ -28,12 +31,12 @@ namespace {
     class log_handler_t :
     public std::enable_shared_from_this<log_handler_t> {
     public:
-        log_handler_t(std::shared_ptr<framework::service<io::log_tag>> _logger, std::string _message, blackhole::attribute::set_t _attributes) :
+        log_handler_t(std::shared_ptr<framework::service<io::log_tag>> _logger, std::string _message, blackhole::attributes_t _attributes) :
             logger(std::move(_logger)),
             message(std::move(_message)),
             attributes(std::move(_attributes))
         {
-            attributes.push_back(blackhole::attribute::make("real_timestamp", current_time()));
+            attributes.push_back({"real_timestamp", current_time()});
         }
 
         void
@@ -59,7 +62,7 @@ namespace {
     private:
         std::shared_ptr<framework::service<io::log_tag>> logger;
         std::string message;
-        blackhole::attribute::set_t attributes;
+        blackhole::attributes_t attributes;
     };
 }
 
@@ -91,7 +94,7 @@ internal_logger_t::log(std::string message) {
     //std::bind here is intentional. We don't want to pass trace there.
     d->loop.post(std::bind(
         &log_handler_t::operator(),
-        std::make_shared<log_handler_t>(d->logger, std::move(message), trace_t::current().attributes<blackhole::attribute::set_t>())
+        std::make_shared<log_handler_t>(d->logger, std::move(message), trace_t::current().attributes<blackhole::attributes_t>())
     ));
 }
 

--- a/tst/func/real/logging.cpp
+++ b/tst/func/real/logging.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <blackhole/attribute.hpp>
+#include <blackhole/extensions/writer.hpp>
 
 #include <cocaine/common.hpp>
 #include <cocaine/idl/logging.hpp>
@@ -24,6 +25,6 @@ TEST(service, Logging) {
         logging::info,
         "app/testing",
         "le message",
-        blackhole::attribute::set_t({{ "key", blackhole::attribute::value_t(42) }})
+        blackhole::attributes_t({{ "key", blackhole::attribute::value_t(42)}})
     ).get();
 }


### PR DESCRIPTION
For consideration only.

Mainly rename `blackhole::attribute::set_t` to `blackhole::attributes_t`.
