### PR TITLE
feat(build): link with small static util lib instead of libcocaine-core

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -58,7 +58,7 @@ add_library(${PROJECT} SHARED ${SOURCES})
 
 target_link_libraries(${PROJECT}
     ${Boost_LIBRARIES}
-    cocaine-core # Temporary link until required.
+    cocaine-util # Temporary link until required.
     msgpack
 )
 


### PR DESCRIPTION
connected with https://github.com/3Hren/cocaine-core/pull/61
Please be aware that build is currently broken, see https://github.com/ijon/cocaine-framework-native/commit/01506b19a371154f38dc09acdb1e6efdad0b1fff
