### PR TITLE
Hide foreign symbols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,9 @@ TARGET_LINK_LIBRARIES(cocaine-framework
 
 SET_TARGET_PROPERTIES(cocaine-framework PROPERTIES
     VERSION 1
-    COMPILE_FLAGS "-std=c++0x -W -Wall -Werror -pedantic")
+    COMPILE_FLAGS "-std=c++0x -W -Wall -Werror -pedantic"
+    LINK_FLAGS "-Wl,--version-script=${PROJECT_SOURCE_DIR}/libcocaine-framework.version"
+)
 
 IF(NOT COCAINE_LIBDIR)
     SET(COCAINE_LIBDIR lib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,8 +44,7 @@ ADD_LIBRARY(cocaine-framework SHARED
     src/handlers/http)
 
 TARGET_LINK_LIBRARIES(cocaine-framework
-    boost_program_options-mt
-    boost_system-mt
+    ${Boost_LIBRARIES}
     ev
     msgpack
     cocaine-core)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,8 @@ SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 FIND_PACKAGE(Boost 1.40.0 REQUIRED
     COMPONENTS
-        program_options)
+        program_options
+        system)
 
 INCLUDE(cmake/locate_library.cmake)
 
@@ -44,6 +45,7 @@ ADD_LIBRARY(cocaine-framework SHARED
 
 TARGET_LINK_LIBRARIES(cocaine-framework
     boost_program_options-mt
+    boost_system-mt
     ev
     msgpack
     cocaine-core)

--- a/cocaine-framework-native-bf.spec
+++ b/cocaine-framework-native-bf.spec
@@ -6,7 +6,7 @@ Release:    2%{?dist}
 License:    GPLv2+
 Group:      System Environment/Libraries
 URL:        http://reverbrain.com
-Source0:    http://repo.reverbrain.com/sources/cocaine-framework-native/%{name}-%{version}.tar.bz2
+Source0:    %{name}-%{version}.tar.bz2
 BuildRoot:  %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildRequires:  boost-devel

--- a/cocaine-framework-native-bf.spec
+++ b/cocaine-framework-native-bf.spec
@@ -1,7 +1,7 @@
 Summary:    Cocaine - Native Framework
 Name:       cocaine-framework-native
-Version:    0.11.0.0
-Release:    1%{?dist}
+Version:    0.11.1.2
+Release:    2%{?dist}
 
 License:    GPLv2+
 Group:      System Environment/Libraries

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+cocaine-framework-native (0.11.1.4) unstable; urgency=low
+
+  * fix object destroying sequence on exit
+
+ -- Andrey Karpov <ndk@yandex.ru>  Tue, 08 Dec 2015 17:06:13 +0300
+
 cocaine-framework-native (0.11.1.3) unstable; urgency=low
 
   * Fix deps for dev package

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+cocaine-framework-native (0.11.1.2) unstable; urgency=low
+
+  * Fix deadlock in service client.
+
+ -- Andrey Goryachev <bugsbunny@yandex-team.ru>  Tue, 06 May 2014 18:25:07 +0400
+
 cocaine-framework-native (0.11.1.1) unstable; urgency=low
 
   * Fix segmentation fault in service manager destructor.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+cocaine-framework-native (0.11.1.1) unstable; urgency=low
+
+  * Fix segmentation fault in service manager destructor.
+
+ -- Andrey Goryachev <bugsbunny@yandex-team.ru>  Fri, 04 Apr 2014 17:17:03 +0400
+
 cocaine-framework-native (0.11.1.0) unstable; urgency=low
 
   * Fixed race in service destructor.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+cocaine-framework-native (0.11.1.3) unstable; urgency=low
+
+  * Fix deps for dev package
+
+ -- Anton Tyurin <noxiouz@yandex-team.ru>  Wed, 28 Jan 2015 14:30:13 +0400
+
 cocaine-framework-native (0.11.1.2) unstable; urgency=low
 
   * Fix deadlock in service client.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+cocaine-framework-native (0.11.1.0) unstable; urgency=low
+
+  * Fixed race in service destructor.
+  * Fixed building on Max OS X.
+  * Warning: binary compatibility is broken.
+
+ -- Andrey Goryachev <bugsbunny@yandex-team.ru>  Wed, 19 Mar 2014 18:08:48 +0400
+
 cocaine-framework-native (0.11.0.3) unstable; urgency=low
 
   * Fixed segmentation fault.

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,9 @@ Source: cocaine-framework-native
 Section: utils
 Priority: extra
 Maintainer: Andrey Goryachev <bugsbunny@yandex-team.ru>
-Build-Depends: cmake, cdbs, debhelper (>= 7.0.13), libcocaine-dev (>= 0.11.0.0), libboost-program-options-dev, libboost-system-dev
+Build-Depends: cmake, cdbs, debhelper (>= 7.0.13), 
+ libcocaine-dev (>= 0.11.0.0), libcocaine-dev (<< 0.12.0.0), 
+ libboost-program-options-dev, libboost-system-dev
 Standards-Version: 3.8.4
 Vcs-Git: git://github.com/cocaine/cocaine-framework-native.git
 Vcs-Browser: https://github.com/cocaine/cocaine-framework-native
@@ -15,7 +17,9 @@ Description: Cocaine - Native Framework
 
 Package: cocaine-framework-native-dev
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, libcocaine-dev (>= 0.11.0.0), cocaine-framework-native (= ${binary:Version})
+Depends: ${shlibs:Depends}, ${misc:Depends}, 
+ libcocaine-dev (>= 0.11.0.0), libcocaine-dev (<< 0.12.0.0),
+ cocaine-framework-native (= ${binary:Version})
 Description: Cocaine - Native Framework Development Headers
  Cocaine Native Framework development headers.
 

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: cocaine-framework-native
 Section: utils
 Priority: extra
 Maintainer: Andrey Goryachev <bugsbunny@yandex-team.ru>
-Build-Depends: cmake, cdbs, debhelper (>= 7.0.13), libcocaine-dev (>= 0.11.0.0), libboost-program-options-dev
+Build-Depends: cmake, cdbs, debhelper (>= 7.0.13), libcocaine-dev (>= 0.11.0.0), libboost-program-options-dev, libboost-system-dev
 Standards-Version: 3.8.4
 Vcs-Git: git://github.com/cocaine/cocaine-framework-native.git
 Vcs-Browser: https://github.com/cocaine/cocaine-framework-native

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -42,7 +42,7 @@ public:
         m_log = d.service_manager()->get_system_logger();
         m_storage = d.service_manager()->get_service<cocaine::framework::storage_service_t>("storage");
 
-        d.on<on_event1>("event1", this);
+        d.on<on_event1>("event1", *this);
         d.on("event2", this, &App1::on_event2);
 
         COCAINE_LOG_WARNING(m_log, "test log");

--- a/libcocaine-framework.version
+++ b/libcocaine-framework.version
@@ -1,0 +1,5 @@
+{
+    global: _ZN7cocaine9framework*; _ZTI*; _ZTS*; _ZTN*; _ZNK*;
+    local: *;
+};
+

--- a/src/service_client/connection.cpp
+++ b/src/service_client/connection.cpp
@@ -273,9 +273,9 @@ service_connection_t::on_message(const cocaine::io::message_t& message) {
     if (it != m_sessions.end()) {
         it->second.stop_timer();
         detail::service::session_data_t data;
-        if (message.id() == io::event_traits<io::rpc::choke>::id) {
-            m_sessions.erase(it);
-        } else if (message.id() == io::event_traits<io::rpc::error>::id) {
+        if (message.id() == io::event_traits<io::rpc::choke>::id ||
+            message.id() == io::event_traits<io::rpc::error>::id)
+        {
             data = it->second;
             m_sessions.erase(it);
         } else {

--- a/src/service_client/manager.cpp
+++ b/src/service_client/manager.cpp
@@ -127,9 +127,9 @@ service_manager_t::~service_manager_t() {
         }
     }
 
+    m_logger.reset();
     m_reactors.clear();
     m_resolver.reset();
-    m_logger.reset();
 }
 
 void

--- a/src/service_client/manager.cpp
+++ b/src/service_client/manager.cpp
@@ -106,7 +106,7 @@ service_manager_t::~service_manager_t() {
     for (size_t i = 0; i < m_reactors.size(); ++i) {
         m_reactors[i]->stop();
     }
-    
+
     for (size_t i = 0; i < m_reactors.size(); ++i) {
         m_reactors[i]->join();
     }
@@ -116,14 +116,20 @@ service_manager_t::~service_manager_t() {
         m_resolver->disconnect();
     }
 
-    std::lock_guard<std::mutex> lock(m_connections_mutex);
-    for (auto it = m_connections.begin(); it != m_connections.end(); ++it) {
-        auto shared = it->weak.lock();
-        if (shared) {
-            shared->auto_reconnect(false);
-            shared->disconnect();
+    {
+        std::lock_guard<std::mutex> lock(m_connections_mutex);
+        for (auto it = m_connections.begin(); it != m_connections.end(); ++it) {
+            auto shared = it->weak.lock();
+            if (shared) {
+                shared->auto_reconnect(false);
+                shared->disconnect();
+            }
         }
     }
+
+    m_reactors.clear();
+    m_resolver.reset();
+    m_logger.reset();
 }
 
 void

--- a/src/service_client/service.cpp
+++ b/src/service_client/service.cpp
@@ -115,9 +115,10 @@ service_t::service_t(std::shared_ptr<service_connection_t> connection) :
 service_t::~service_t() {
     if (m_connection) {
         m_connection->auto_reconnect(false);
-        m_connection->reactor().post(std::bind(&service_connection_t::disconnect,
-                                               std::move(m_connection),
-                                               service_status::disconnected));
+        auto &reactor = m_connection->reactor();
+        reactor.post(std::bind(&service_connection_t::disconnect,
+                               std::move(m_connection),
+                               service_status::disconnected));
     }
 }
 
@@ -150,6 +151,7 @@ namespace {
 void
 service_t::soft_destroy() {
     m_connection->auto_reconnect(false);
-    m_connection->reactor().post(std::bind(&emptyf<std::shared_ptr<service_connection_t>>::call,
-                                           std::move(m_connection)));
+    auto &reactor = m_connection->reactor();
+    reactor.post(std::bind(&emptyf<std::shared_ptr<service_connection_t>>::call,
+                           std::move(m_connection)));
 }


### PR DESCRIPTION
Hide all symbols except those from cocaine::framework namespace (which constitute public library interface) and typeinfo stuff.

Most important result is concealment of boost::asio symbols.
