### PR TITLE
fix(cmake): use proper library name to link to

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -58,7 +58,7 @@ add_library(${PROJECT} SHARED ${SOURCES})
 
 target_link_libraries(${PROJECT}
     ${Boost_LIBRARIES}
-    cocaine-util # Temporary link until required.
+    cocaine-io-util
     msgpack
     blackhole
 )


### PR DESCRIPTION
bound to https://github.com/3Hren/cocaine-core/pull/91
